### PR TITLE
Remove wsgiref from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ Jinja2==2.7.3
 MarkupSafe==0.23
 Werkzeug==0.10.1
 itsdangerous==0.24
-wsgiref==0.1.2


### PR DESCRIPTION
This allows the example to run on Python 3 which is the new Heroku
default runtime.

Closes #7